### PR TITLE
Feat/0122

### DIFF
--- a/solve/src/a_data_structure/BinaryHeap.java
+++ b/solve/src/a_data_structure/BinaryHeap.java
@@ -1,0 +1,62 @@
+package a_data_structure;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BinaryHeap { // 최소 힙
+	public List<Integer> elements;
+
+	public BinaryHeap() {
+		elements = new ArrayList<>();
+		elements.add(null); // index = 0 -> null
+	}
+
+	public void swap(int i, int j) {
+		Integer tmp = elements.get(i);
+		elements.set(j, elements.get(i));
+		elements.set(i, tmp);
+	}
+
+	// to insert
+	public void upHeap() {
+		int i = elements.size() - 1;
+		int parentIndex = i / 2;
+
+		while (parentIndex > 0) {
+			if (elements.get(parentIndex) > elements.get(i)) {
+				swap(i, parentIndex);
+			}
+			i = parentIndex;
+			parentIndex = i / 2;
+		}
+	}
+
+	public void insert(int k) {
+		elements.add(k);
+		upHeap();
+	}
+
+	// to pop
+	public void downHeap(int i) {
+		int left = i * 2;
+		int right = i * 2 + 1;
+		int smallest = i; // 현재 노드를 가장 작은 값으로 가정
+
+		if (left <= elements.size() - 1 && elements.get(left) < elements.get(smallest)) smallest = left;
+		if (right <= elements.size() - 1 && elements.get(right) < elements.get(smallest)) smallest = right;
+		if (smallest != i) { // 나보다 더 작은 원소가 있다면 스왑
+			swap(smallest, i);
+			downHeap(smallest);
+		}
+	}
+
+	public Integer extract() {
+		int res = elements.get(1);
+
+		elements.set(1, elements.get(elements.size() - 1));
+		elements.remove(elements.size() - 1);
+		downHeap(1);
+
+		return res;
+	}
+}

--- a/solve/src/b_sorting/leetcode148/Solution.java
+++ b/solve/src/b_sorting/leetcode148/Solution.java
@@ -1,0 +1,44 @@
+package b_sorting.leetcode148;
+
+class Solution {
+	public ListNode sortList(ListNode head) {
+		if (head == null || head.next == null) return head;
+
+		// 연결 리스트의 중앙과 끝노드 알아내기
+		ListNode half = null, slow = head, fast = head;
+		while (fast != null && fast.next != null) {
+			half = slow;
+			slow = slow.next; // 중앙노드
+			fast = fast.next.next;
+		}
+		half.next = null; // 연결리스트를 두개로 분할
+
+		ListNode l1 = sortList(head); // 앞쪽 연결리스트
+		ListNode l2 = sortList(slow); // 뒷쪽 연결리스트
+
+		return mergeTwoList(l1, l2);
+	}
+
+	// l1에 l2를 정렬하면서 붙인다.
+	public ListNode mergeTwoList(ListNode l1, ListNode l2) {
+		if (l1 == null) return l2;
+		if (l2 == null) return l1;
+
+		// 앞의 노드 값이 더 크면 swap
+		if (l1.val > l2.val) {
+			ListNode temp = l1;
+			l1 = l2;
+			l2 = temp;
+		}
+		l1.next = mergeTwoList(l1.next, l2);
+		return l1;
+	}
+
+	public static class ListNode {
+		int val;
+		ListNode next;
+		ListNode() {}
+		ListNode(int val) { this.val = val; }
+		ListNode(int val, ListNode next) { this.val = val; this.next = next; }
+	}
+}

--- a/solve/src/b_sorting/leetcode56/Solution.java
+++ b/solve/src/b_sorting/leetcode56/Solution.java
@@ -1,0 +1,23 @@
+package b_sorting.leetcode56;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+class Solution {
+	public int[][] merge(int[][] intervals) {
+		List<int[]> arr = new ArrayList<>();
+		Arrays.sort(intervals, Comparator.comparingInt(a -> a[0]));
+
+		for (int[] i : intervals) {
+			if (!arr.isEmpty() && i[0] <= arr.get(arr.size() - 1)[1]) {
+				arr.get(arr.size() - 1)[1] = Math.max(arr.get(arr.size() - 1)[1], i[1]);
+			} else {
+				arr.add(i);
+			}
+		}
+
+		return arr.toArray(new int[arr.size()][]);
+	}
+}


### PR DESCRIPTION
## 자료구조
### 힙
부모와 자식간의 관계를 정의한 트리 기반의 자료구조

- 루트에 가장 큰 값이나 작은 값을 두어 최대 혹은 최소 값을 빠르게 찾을 수 있다.
- 리프노드를 제외하고는 완전 트리를 유지하기 때문에 삽입, 삭제에 O(log N)이 소요된다.
- 부모 노드가 자식 노드보다 크거나 작다는 조건을 만족할 뿐 전체적으로 정렬되어 있지는 않다.

- 삽입
    1. 엘리먼트를 가장 하위 레빌의 최대한 왼쪽으로 삽입 (배열에서 가장 마지막)
    2. 부모 값과 비교하여 값이 더 작은 경우 위치 변경
    3. 2번을 반복
- 추출
    1. 루트노드를 추출하고 가장 마지막 엘리먼트를 루트자리로 이동
    2. 자식노드와 비교하면서 자식노드의 값이 더 작으면 위치변경
    3. 2번 반복

- 이진탐색트리와 이진힙의 차이점은?
   - 이진탐색트리는 좌우 관계를 정의하고, 이진힙은 상하관계를 정의한다. 이진트리를 전체적으로 정렬되어 있지만 이진힙은 부모와 자식 노드만 조건에 맞게 정렬되어있고 전체적으로는 정렬되어 있지 않음 


## 알고리즘
### 정렬
- 리스트의 원소를 기준에 따라 순서대로 나열하는 알고리즘

### 버블정렬
N개를 N번 반복하며 연달아 있는 원소 2개를 비교하여 정렬
- 간단하지만 시간 복잡도가 O(n^2)로 느리다.

### 삽입정렬
정렬된 리스트 중 정렬하려는 원소가 들어갈 자리를 찾아서 삽입하며 정렬
- 단순하다. 자신의 위치를 찾기 위해서 매번 정렬된 리스트를 전체 탐색하므로 입력값이 커질수록 성능이 떨어진다. 
- 평균 시간 복잡도 O(n^2)
   - 각 요소의 삽입 위치를 찾기 위해 O(n)번 비교하고, 이를 n개의 요소에 대해 반복 

### 병합정렬
입력값을 더이상 쪼갤 수 없을 때까지 분할한 후 분할한 값들을 정렬하며 병합
- 시간복잡도 O(NlogN)
- 안정 정렬 - 값이 같으면 입력순서가 유지되어요

### 퀵정렬
pivot을 기준으로 작으면 왼쪽, 크면 오른쪽에 위치시키며 정렬한다. 
- pivot을 어떻게 선정하는지가 핵심
   - 왜냐면 pivot을 잘못 선정하면 pivot 기준으로 분할이 이루어지지 않아 입력값만큼 전체를 비교하게 되기 때문
- 시간복잡도 O(NlogN) / 최악의 경우 O(n^2)
   - 최악의 경우 -> 이미 정렬된 오름차순 배열 + pivot을  가장 오른쪽 걸로 선정
- 불안정 정렬 - 입력순서 유지안됨

- #22 
  