### PR TITLE
Feat/0123

### DIFF
--- a/solve/src/pg258711/Solution.java
+++ b/solve/src/pg258711/Solution.java
@@ -1,0 +1,36 @@
+package pg258711;
+
+import java.util.*;
+
+class Solution {
+	public int[] solution(int[][] edges) {
+		int[] answer = {0, 0, 0, 0};
+
+		Map<Integer, int[]> info = new HashMap<>(); // int[0] -> in, int[1] -> out
+		for(int[] e : edges) {
+			if (!info.containsKey(e[0])) info.put(e[0], new int[2]);
+			if (!info.containsKey(e[1])) info.put(e[1], new int[2]);
+			info.get(e[0])[1]++;
+			info.get(e[1])[0]++;
+		}
+
+		Set<Map.Entry<Integer, int[]>> entrySet = info.entrySet();
+		for (Map.Entry<Integer, int[]> element : entrySet) {
+			int[] v = element.getValue();
+			if (v[0] == 0 && v[1] > 1) answer[0] = element.getKey();
+			if (v[0] >= 1 && v[1] == 0) answer[2]++;
+			if (v[0] >= 2 && v[1] >= 2) answer[3]++;
+		}
+		answer[1] = info.get(answer[0])[1] - answer[2] - answer[3];
+		return answer;
+	}
+
+	public static void main(String[] args) {
+		// [[4, 11], [1, 12], [8, 3], [12, 7], [4, 2], [7, 11], [4, 8], [9, 6], [10, 11], [6, 10], [3, 5], [11, 1], [5, 3], [11, 9], [3, 8]]
+		int[][] edges = {
+			{4, 11}, {1, 12}, {8, 3}, {12, 7}, {4, 2}, {7, 11}, {4, 8}, {9, 6}, {10, 11}, {6, 10}, {3, 5}, {11, 1}, {5, 3}, {11, 9}, {3, 8}
+		};
+		int[] result = new Solution().solution(edges);
+		System.out.println(Arrays.toString(result));
+	}
+}

--- a/solve/src/pg258711/SolutionArr.java
+++ b/solve/src/pg258711/SolutionArr.java
@@ -1,0 +1,35 @@
+package pg258711;
+
+import java.util.*;
+
+class SolutionArr {
+	public int[] solution(int[][] edges) {
+		int[] answer = {0, 0, 0, 0};
+
+		int[] in = new int[1_000_000];
+		int[] out = new int[1_000_000];
+		for(int[] e : edges) {
+			out[e[0]]++;
+			in[e[1]]++;
+		}
+
+		for (int i = 1; i < 1_000_000; i++) {
+			if (in[i] == 0 && out[i] == 0) continue;
+
+			if (in[i] == 0 && out[i] > 1) answer[0] = i;
+			if (in[i] >= 1 && out[i] == 0) answer[2]++;
+			if (in[i] >= 2 && out[i] >= 2) answer[3]++;
+		}
+		answer[1] = out[answer[0]] - answer[2] - answer[3];
+		return answer;
+	}
+
+	public static void main(String[] args) {
+		// [[4, 11], [1, 12], [8, 3], [12, 7], [4, 2], [7, 11], [4, 8], [9, 6], [10, 11], [6, 10], [3, 5], [11, 1], [5, 3], [11, 9], [3, 8]]
+		int[][] edges = {
+			{4, 11}, {1, 12}, {8, 3}, {12, 7}, {4, 2}, {7, 11}, {4, 8}, {9, 6}, {10, 11}, {6, 10}, {3, 5}, {11, 1}, {5, 3}, {11, 9}, {3, 8}
+		};
+		int[] result = new Solution().solution(edges);
+		System.out.println(Arrays.toString(result));
+	}
+}


### PR DESCRIPTION
### 알고리즘 풀이

[프로그래머스 Lv2. 도넛과 막대 그래프](https://school.programmers.co.kr/learn/courses/30/lessons/258711)

HashMap으로 풀었을 때
![image](https://github.com/user-attachments/assets/f7c0dc03-9a1f-45d3-99f6-a531596fff16)

배열로 풀었을 때 
![image](https://github.com/user-attachments/assets/6c9bd2f3-34f7-405b-96b8-76e5069480e4)

- 정리
  - 배열은 인덱스 접근 속도가 O(1)이고 메모리에 연속적으로 저장되므로 캐시 친화적(한 번 로드하면 여러 개의 데이터를 캐시에서 가져올 수 있음)이라서 빠르다. 
  - HashMap은 내부적으로 해시 버킷을 사용하여 데이터를 저장하는데, 해시 충돌을 피하기 위해 비연속적인 메모리 위치에 데이터가 저장되어 배열보다 느림, 또 데이터를 찾을 때 해시 함수를 연산하고, 같은 해시 값이 있는 경우 추가 비교 연산이 필요함

  - HashMap은 컬렉션이라서 저장할 때 wapper 타입으로 저장해야함 + 또한, 해시 테이블의 구조상 버킷(bucket) 충돌을 고려해야함 -> 배열에 비해 메모리 사용량 증가
